### PR TITLE
Adding double quotes so we could add values with a space

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,7 +2,7 @@
 # tasks file for sysctl
 
 - name: set sysctl rules
-  sysctl: name={{ item.key }} value={{ item.value }}
+  sysctl: name="{{ item.key }}" value="{{ item.value }}"
   with_dict: sysctl_rules
   when: sysctl_rules is defined
   tags: [sysctl]


### PR DESCRIPTION
With the previous version I found a problem trying to add a composed sysctl setting as:

```
net.ipv4.ip_local_port_range: 2000 65535
```

Enclosing {{ item.key }} and {{ item.value }} between double quotes solves the issue.
